### PR TITLE
fixed random background color generation in tiles0

### DIFF
--- a/tiles0/main.lua
+++ b/tiles0/main.lua
@@ -36,9 +36,9 @@ function love.load()
     mapWidth = 20
     mapHeight = 20
 
-    backgroundR = math.random(255) / 255 / 255
-    backgroundG = math.random(255) / 255 / 255
-    backgroundB = math.random(255) / 255 / 255
+    backgroundR = math.random(255) / 255
+    backgroundG = math.random(255) / 255
+    backgroundB = math.random(255) / 255
 
     for y = 1, mapHeight do
         table.insert(tiles, {})


### PR DESCRIPTION
backgroundR, backgroundG and backgroundB are multiplied by 255 twice resulting in generating (almost) black color every time.