### PR TITLE
Fix wrong gravity calculation

### DIFF
--- a/mario/src/states/entity/PlayerFallingState.lua
+++ b/mario/src/states/entity/PlayerFallingState.lua
@@ -22,7 +22,7 @@ end
 
 function PlayerFallingState:update(dt)
     self.player.currentAnimation:update(dt)
-    self.player.dy = self.player.dy + self.gravity
+    self.player.dy = self.player.dy + (self.gravity * dt)
     self.player.y = self.player.y + (self.player.dy * dt)
 
     -- look at two tiles below our feet and check for collisions

--- a/mario/src/states/entity/PlayerJumpState.lua
+++ b/mario/src/states/entity/PlayerJumpState.lua
@@ -25,7 +25,7 @@ end
 
 function PlayerJumpState:update(dt)
     self.player.currentAnimation:update(dt)
-    self.player.dy = self.player.dy + self.gravity
+    self.player.dy = self.player.dy + (self.gravity * dt)
     self.player.y = self.player.y + (self.player.dy * dt)
 
     -- go into the falling state when y velocity is positive

--- a/mario/src/states/game/PlayState.lua
+++ b/mario/src/states/game/PlayState.lua
@@ -16,7 +16,7 @@ function PlayState:init()
     self.backgroundX = 0
 
     self.gravityOn = true
-    self.gravityAmount = 6
+    self.gravityAmount = 420
 
     self.player = Player({
         x = 0, y = 0,

--- a/mario/src/states/game/PlayState.lua
+++ b/mario/src/states/game/PlayState.lua
@@ -16,7 +16,7 @@ function PlayState:init()
     self.backgroundX = 0
 
     self.gravityOn = true
-    self.gravityAmount = 420
+    self.gravityAmount = 360
 
     self.player = Player({
         x = 0, y = 0,


### PR DESCRIPTION
Fix the wrong gravity calculation in the game.

I chose (6 * 60 =) 360 to keep the gameplay same as it was before this fix,
this PR will allow this same gameplay to be consistent across all frame rates